### PR TITLE
fixes #5 - moved margin:60px auto to demo.html page

### DIFF
--- a/css/px-spinner-sketch.css
+++ b/css/px-spinner-sketch.css
@@ -183,9 +183,7 @@ html {
   /*! Comment to prevent cssmin munging this rule with html above and borking Safari */
   box-sizing: border-box; }
 
-*,
-*:before,
-*:after {
+*, *:before, *:after {
   box-sizing: inherit; }
 
 /**
@@ -213,6 +211,9 @@ html {
      */
 /**
  * Monochromatic (gray10 is darkest, gray1 is lightest)
+ */
+/**
+ * Define grey = gray to avoid dev typos
  */
 /**
  * Buttons
@@ -248,15 +249,13 @@ a {
   /**
  * Improve readability when focused and also mouse hovered in all browsers.
  */ }
-  a:link,
-  a:visited {
+  a:link, a:visited {
     color: #3e87e8; }
   a:hover {
     color: #3573c5; }
   a:active {
     color: #2b5ea2; }
-  a:active,
-  a:hover {
+  a:active, a:hover {
     outline: 0; }
 
 /**
@@ -339,9 +338,9 @@ a {
   padding: 0 !important;
   clip: rect(0 0 0 0) !important; }
 
-.a11y.focusable:active,
-.a11y.focusable:focus,
-.visuallyhidden.focusable:active, .visuallyhidden.focusable:focus {
+.a11y.focusable:active, .a11y.focusable:focus,
+.visuallyhidden.focusable:active,
+.visuallyhidden.focusable:focus {
   position: static;
   overflow: visible;
   width: auto;
@@ -657,8 +656,10 @@ a {
   display: -ms-flexbox;
   display: flex; }
 
+:host {
+  display: block; }
+
 .spinner {
-  margin: 60px auto;
   font-size: 10px;
   position: relative;
   text-indent: -9999em;

--- a/css/px-spinner.css
+++ b/css/px-spinner.css
@@ -30,6 +30,9 @@ common/abstract rules go in px-spinner-sketch.scss, not in this file.
  * Monochromatic (gray10 is darkest, gray1 is lightest)
  */
 /**
+ * Define grey = gray to avoid dev typos
+ */
+/**
  * Buttons
  */
 /**
@@ -234,9 +237,7 @@ html {
   /*! Comment to prevent cssmin munging this rule with html above and borking Safari */
   box-sizing: border-box; }
 
-*,
-*:before,
-*:after {
+*, *:before, *:after {
   box-sizing: inherit; }
 
 /**
@@ -261,15 +262,13 @@ a {
   /**
  * Improve readability when focused and also mouse hovered in all browsers.
  */ }
-  a:link,
-  a:visited {
+  a:link, a:visited {
     color: #3e87e8; }
   a:hover {
     color: #3573c5; }
   a:active {
     color: #2b5ea2; }
-  a:active,
-  a:hover {
+  a:active, a:hover {
     outline: 0; }
 
 /**
@@ -352,9 +351,9 @@ a {
   padding: 0 !important;
   clip: rect(0 0 0 0) !important; }
 
-.a11y.focusable:active,
-.a11y.focusable:focus,
-.visuallyhidden.focusable:active, .visuallyhidden.focusable:focus {
+.a11y.focusable:active, .a11y.focusable:focus,
+.visuallyhidden.focusable:active,
+.visuallyhidden.focusable:focus {
   position: static;
   overflow: visible;
   width: auto;
@@ -670,8 +669,10 @@ a {
   display: -ms-flexbox;
   display: flex; }
 
+:host {
+  display: block; }
+
 .spinner {
-  margin: 60px auto;
   font-size: 10px;
   position: relative;
   text-indent: -9999em;

--- a/demo.html
+++ b/demo.html
@@ -20,6 +20,9 @@
       text-align:center;
       margin-top:70px;
     }
+    px-spinner {
+      margin: 60px auto;
+    }
   </style>
   <h3>Demo</h3>
 

--- a/px-spinner.html
+++ b/px-spinner.html
@@ -34,6 +34,10 @@ is being done for an indefinite period of time.
         ready: function() {
           this.$.Wrapper.style.width = this.size + 'px';
           this.$.Wrapper.style.height = this.size + 'px';
+
+          // Styling the px-spinner elem so it can be positioned properly
+          this.style.width = this.size + 'px';
+          this.style.height = this.size + 'px';
         },
         is: 'px-spinner',
 
@@ -83,7 +87,8 @@ is being done for an indefinite period of time.
          * @method show
          */
         show: function() {
-          this.$.Wrapper.style.display = 'block';
+          // Setting display to '' instead of 'block' allows user defined css to still work
+          this.style.display = '';
         },
 
         /**
@@ -92,7 +97,7 @@ is being done for an indefinite period of time.
          * @method hide
          */
         hide: function () {
-          this.$.Wrapper.style.display = 'none';
+          this.style.display = 'none';
         }
 
     });

--- a/sass/px-spinner-sketch.scss
+++ b/sass/px-spinner-sketch.scss
@@ -36,9 +36,11 @@ $inuit-enable-layout--full : true;
 
 // Component
 
+:host {
+  display: block;
+}
 
 .spinner {
-  margin: 60px auto;
   font-size: 10px;
   position: relative;
   text-indent: -9999em;


### PR DESCRIPTION
the extra margin on the #Wrapper div causes unwanted layout issues. moved that css to the demo.html  page. now users can use the element in more predictable manner

also updated the hide/show to actually hide/show the px-spinner itself, since the width and height had to be set on the px-spinner, this was necessary to not have empty white space when hiding 